### PR TITLE
fix: Sprint 1 — kritiske bugs og sikkerhed (#13, #15, #18, #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,98 @@
-# React + Vite
+# Stemmer fra Norddjurs
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Borgerdeltagelsesplatform til Norddjurs Kommune til indsamling af borgerholdninger via tekst og lydoptagelser — til brug i budgetprocessen "Sammen om Norddjurs".
 
-Currently, two official plugins are available:
+## Hvad er dette?
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Platformen giver borgere mulighed for at besvare politiske spørgsmål via tekst eller kortlydsoptagelse (maks. 90 sek.). En lokal AI-model genererer automatisk opfølgningsspørgsmål baseret på borgerens svar og andre borgeres perspektiver.
 
-## React Compiler
+Administratorer kan via et dashboard se besvarelser, køre AI-analyse (temaer, sentiment, citater), moderere indhold og eksportere data som CSV.
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+**Al databehandling foregår 100% lokalt på kommunens server — ingen data forlader netværket.**
 
-## Expanding the ESLint configuration
+## Funktioner
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+- Tekst- og lydbesvarelser med lokal talegenkendelses (dansk Røst v2)
+- AI-opfølgningsspørgsmål via lokal Ollama (Qwen 14B)
+- Sentimentanalyse med to danske BERT-modeller
+- GDPR-compliance: samtykke, dataeksport, sletning og frysning
+- Admin-dashboard med filtrering, moderation og CSV-eksport
+- Borgerspørgsmål med godkendelsesflow
+
+## Teknologi
+
+| Lag | Teknologi |
+|---|---|
+| Frontend | React 19, Vite |
+| Backend | FastAPI (Python 3.11+) |
+| Database | SQLite (dev) / MS SQL Server (prod) |
+| AI / LLM | Ollama — Qwen 14B (lokalt) |
+| Talegenkendelses | CoRal Røst v2 wav2vec2 (lokalt) |
+| Sentiment | DaNLP + AlexandraInst BERT (lokalt) |
+
+## Kom i gang (lokal udvikling)
+
+### Forudsætninger
+
+- Python 3.11+
+- Node.js 18+
+- [Ollama](https://ollama.com) installeret og kørende
+
+### Backend
+
+```bash
+cd backend
+pip install -r requirements.txt
+cp .env.example .env   # udfyld SECRET_KEY og øvrige variabler
+python main.py
+```
+
+Første opstart opretter databasen, seeder testdata og printer et tilfældigt admin-kodeord i terminalen.
+
+API docs: [http://localhost:8321/docs](http://localhost:8321/docs)
+
+### Frontend
+
+```bash
+npm install
+npm run dev
+```
+
+Åbn [http://localhost:5173](http://localhost:5173)
+
+### AI-model (valgfrit til lokal udvikling)
+
+```bash
+ollama pull qwen3:8b
+```
+
+Uden Ollama virker alt undtagen AI-opfølgningsspørgsmål og analyse.
+
+## Produktion
+
+Se [SETUP.md](SETUP.md) for komplet produktionsopsætning med IIS, MS SQL Server, GPU og Ollama på Windows-server.
+
+## Tests
+
+```bash
+cd backend
+pytest
+```
+
+## Arkitektur
+
+```
+React Frontend (IIS → port 443)
+        │
+        ▼
+FastAPI Backend (port 8321)
+        │
+   ┌────┴────┐
+   │         │
+MS SQL    Ollama + Røst v2
+Server    (lokal GPU)
+```
+
+## Licens
+
+MIT — se [LICENSE](LICENSE)

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -101,8 +101,10 @@ async def get_optional_citizen(
         citizen_id = payload.get("sub")
         if citizen_id and payload.get("role") == "citizen":
             return db.query(Citizen).filter(Citizen.id == citizen_id).first()
-    except:
+    except HTTPException:
         pass
+    except Exception as e:
+        print(f"[Auth] Uventet fejl i get_optional_citizen: {e}")
     return None
 
 

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -7,8 +7,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from database import get_db
-from models import Forloeb, Theme, Question, Citizen, Area
-from auth import get_current_citizen
+from models import Forloeb, Theme, Question, Citizen, Area, AdminUser
+from auth import get_current_citizen, get_current_admin
 from schemas import AreaCreate, CitizenQuestionCreate
 from serializers import (
     forloeb_dict, theme_dict, question_dict,
@@ -128,7 +128,7 @@ def get_areas(db: Session = Depends(get_db)):
 
 
 @router.post("/areas")
-def create_area(data: AreaCreate, db: Session = Depends(get_db)):
+def create_area(data: AreaCreate, admin: AdminUser = Depends(get_current_admin), db: Session = Depends(get_db)):
     name = data.name.strip()
     if not name or len(name) > 100:
         raise HTTPException(400, "Ugyldigt områdenavn")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -47,7 +47,7 @@ def citizen_token(client):
     client.post("/api/citizen/register", json={"email": email, "password": "TestPass1!"})
     r = client.post("/api/citizen/login", json={"email": email, "password": "TestPass1!"})
     assert r.status_code == 200, f"Login fejlede: {r.text}"
-    return r.json()["access_token"]
+    return r.json()["token"]
 
 
 @pytest.fixture

--- a/backend/tests/test_citizen.py
+++ b/backend/tests/test_citizen.py
@@ -19,7 +19,7 @@ class TestCitizenRegister:
         })
         assert r.status_code == 200
         data = r.json()
-        assert "access_token" in data
+        assert "token" in data
 
     def test_register_duplicate_email(self, client):
         email = unique_email()
@@ -46,7 +46,7 @@ class TestCitizenLogin:
         client.post("/api/citizen/register", json={"email": email, "password": VALID_PASSWORD})
         r = client.post("/api/citizen/login", json={"email": email, "password": VALID_PASSWORD})
         assert r.status_code == 200
-        assert "access_token" in r.json()
+        assert "token" in r.json()
 
     def test_login_wrong_password(self, client):
         email = unique_email()
@@ -83,7 +83,7 @@ class TestCitizenChangePassword:
         email = unique_email()
         client.post("/api/citizen/register", json={"email": email, "password": VALID_PASSWORD})
         login = client.post("/api/citizen/login", json={"email": email, "password": VALID_PASSWORD})
-        token = login.json()["access_token"]
+        token = login.json()["token"]
 
         r = client.put(
             "/api/citizen/change-password",


### PR DESCRIPTION
## Sammenfatning

Sprint 1 fra code review — fire hurtige fixes der alle kan være inde på under 30 minutter og bør merges hurtigst muligt.

## Ændringer

### #13 — Broken test-fixtures (`conftest.py` + `test_citizen.py`)
Login-endpointet returnerer `{"token": ...}`, men fixtures og tests ledte efter `"access_token"` — alle citizen-tests kastede `KeyError` og kunne ikke køre.

- `conftest.py:50` — `r.json()["access_token"]` → `r.json()["token"]`
- `test_citizen.py:22` — `"access_token" in data` → `"token" in data`
- `test_citizen.py:49` — `"access_token" in r.json()` → `"token" in r.json()`
- `test_citizen.py:86` — `login.json()["access_token"]` → `login.json()["token"]`

### #15 — `POST /api/areas` manglede auth
Endpointet var tilgængeligt for alle uden login — enhver kunne tilføje nye geografiske områder til systemet.

- Tilføjet `admin: AdminUser = Depends(get_current_admin)` til `create_area`
- Importeret `get_current_admin` og `AdminUser` i `public.py`

### #18 — Bare `except:` i `get_optional_citizen`
Et blankt `except:` maskerede alle undtagelser inkl. `SystemExit` og `MemoryError`.

- Opdelt i `except HTTPException: pass` (forventede token-fejl) og `except Exception as e: print(...)` (uventede fejl logges)

### #27 — README.md var umodificeret Vite-boilerplate
Filen indeholdt ingen projektinformation overhovedet.

- Erstattet med projektspecifik README: formål, funktioner, teknologistak, kom-i-gang-guide, arkitekturoverblik og link til SETUP.md

## Test plan

- [ ] `cd backend && pytest tests/test_citizen.py -v` — alle citizen-tests grønne
- [ ] `curl -X POST /api/areas -d '{"name":"test"}'` returnerer `401` (ikke `200`)
- [ ] Backend starter uden warnings om bare `except`
- [ ] README.md ser korrekt ud på GitHub

## Relaterede issues

Closes #13
Closes #15
Closes #18
Closes #27

> **Note:** `TestCitizenChangePassword`-tests vil stadig fejle indtil #14 (manglende `current_password`-verificering) er implementeret i Sprint 2.

https://claude.ai/code/session_01QST3fNfc98pBpsiGXkBM4V