### PR TITLE
fix(security): fjern application/octet-stream fra MIME-whitelist (#19)

### DIFF
--- a/backend/constants.py
+++ b/backend/constants.py
@@ -24,7 +24,7 @@ ALLOWED_AUDIO_MIMETYPES = {
     "audio/m4a",
     "audio/x-m4a",
     "video/webm",           # Browsers sender ofte webm/opus som video/webm
-    "application/octet-stream",  # Fallback når browser ikke sætter korrekt MIME
+    # application/octet-stream fjernet — for generisk og åbner for vilkårlig filupload
 }
 
 # ─── AI / analyse ──────────────────────────────────────────────────────────────

--- a/backend/routers/responses.py
+++ b/backend/routers/responses.py
@@ -54,8 +54,8 @@ MAX_UPLOAD_BYTES = int(os.getenv("MAX_UPLOAD_SIZE_MB", str(MAX_UPLOAD_SIZE_MB)))
 async def transcribe_preview(request: Request, file: UploadFile = File(...)):
     """Transskribér lyd til tekst uden at gemme som besvarelse — bruges til preview."""
     content_type = (file.content_type or "").split(";")[0].strip()
-    if content_type and content_type not in ALLOWED_AUDIO_MIMETYPES:
-        raise HTTPException(415, f"Ikke-understøttet filformat: {content_type}")
+    if not content_type or content_type not in ALLOWED_AUDIO_MIMETYPES:
+        raise HTTPException(415, f"Ikke-understøttet filformat: {content_type or 'ukendt'}")
 
     contents = await file.read(MAX_UPLOAD_BYTES + 1)
     if len(contents) > MAX_UPLOAD_BYTES:
@@ -145,8 +145,8 @@ async def submit_audio_response(
 ):
     """Upload lyd, transskribér, og gem som response."""
     content_type = (file.content_type or "").split(";")[0].strip()
-    if content_type and content_type not in ALLOWED_AUDIO_MIMETYPES:
-        raise HTTPException(415, f"Ikke-understøttet filformat: {content_type}")
+    if not content_type or content_type not in ALLOWED_AUDIO_MIMETYPES:
+        raise HTTPException(415, f"Ikke-understøttet filformat: {content_type or 'ukendt'}")
 
     contents = await file.read(MAX_UPLOAD_BYTES + 1)
     if len(contents) > MAX_UPLOAD_BYTES:


### PR DESCRIPTION
## Sammenfatning

`application/octet-stream` var inkluderet i listen over tilladte MIME-typer for lydupload. Denne generiske type kan bruges til at uploade **vilkårlige filer** ved blot at sætte den rigtige Content-Type header.

## Ændringer

**`backend/constants.py`**
- Fjernet `application/octet-stream` fra `ALLOWED_AUDIO_MIMETYPES`

**`backend/routers/responses.py`** (begge upload-endpoints)
- Valideringslogik strammet: `if content_type and content_type not in ...` → `if not content_type or content_type not in ...`
- Tom eller ukendt MIME-type afvises nu eksplicit med `415 Unsupported Media Type` i stedet for at glide igennem

## Test plan

- [ ] Upload lydfil (webm/mp3/wav) → virker stadig som forventet
- [ ] Upload fil med `Content-Type: application/octet-stream` → returnerer `415`
- [ ] Upload fil uden Content-Type header → returnerer `415`
- [ ] Manuel test i Chrome og Safari (mobil) for at verificere at browser-genererede MIME-typer stadig accepteres

## Relaterede issues

Closes #19

https://claude.ai/code/session_01QST3fNfc98pBpsiGXkBM4V