### PR TITLE
fix(frontend): læs API_BASE fra miljøvariabel i stedet for hardkodet URL (#16)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,4 @@
+# Produktion — frontend miljøvariabler
+# IIS proxier /api/* til backend, så API_BASE er tom (relative URLs)
+
+VITE_API_BASE=

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ env/
 # Environment variables (ALDRIG commit credentials)
 .env
 .env.local
-.env.production
+.env.development
+# .env.production committes (indeholder ingen hemmeligheder — kun VITE_API_BASE=)
 
 # Database (lokal testdata)
 *.db

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 
 // ─── API ───
-const API_BASE = "http://localhost:8321";
+// I udvikling: sæt VITE_API_BASE=http://localhost:8321 i .env.development
+// I produktion: lad den være tom — IIS proxier /api/* til backend
+const API_BASE = import.meta.env.VITE_API_BASE ?? "";
 
 const apiFetch = (path, options = {}, token = null) => {
   const headers = { ...(options.headers || {}) };


### PR DESCRIPTION
## Sammenfatning

`API_BASE` var hardkodet til `http://localhost:8321` i `App.jsx`. I produktion peger frontenden dermed direkte mod localhost i stedet for at bruge IIS-proxyens relative URL-sti — dette forårsager fejlslagne API-kald og CORS-fejl i produktion.

## Ændringer

**`src/App.jsx`**
```js
// Før:
const API_BASE = "http://localhost:8321";

// Efter:
const API_BASE = import.meta.env.VITE_API_BASE ?? "";
```

**`.env.production`** (ny fil — committes, ingen hemmeligheder)
```env
VITE_API_BASE=
```
Tom værdi → relative URLs (`/api/...`) → IIS-proxyen håndterer routing til backend.

**`.gitignore`**
- `.env.development` tilføjet til ignore-listen (oprettes lokalt af hver udvikler)
- `.env.production` fjernet fra ignore-listen (safe at versionstyres)

## Lokal opsætning (én gang pr. udvikler)

```bash
# Opret lokalt — committes ikke
echo "VITE_API_BASE=http://localhost:8321" > .env.development
```

## Test plan

- [ ] `npm run dev` → frontend kalder `http://localhost:8321/api/...` (via `.env.development`)
- [ ] `npm run build` → bundlet kode bruger relative URLs `/api/...` (via `.env.production`)
- [ ] Ingen hardkodet `localhost` i `dist/`-output: `grep -r "localhost:8321" dist/`

## Relaterede issues

Closes #16

https://claude.ai/code/session_01QST3fNfc98pBpsiGXkBM4V