### PR TITLE
fix(security): kræv current_password ved kodeordsskift (#14)

### DIFF
--- a/backend/routers/citizen.py
+++ b/backend/routers/citizen.py
@@ -181,6 +181,8 @@ def citizen_change_password(
     citizen: Citizen = Depends(get_current_citizen),
     db: Session = Depends(get_db),
 ):
+    if not verify_password(data.current_password, citizen.password_hash):
+        raise HTTPException(401, "Nuværende adgangskode er forkert")
     if data.new_password != data.confirm_password:
         raise HTTPException(400, "Adgangskoderne er ikke ens")
     err = validate_citizen_password(data.new_password)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -96,6 +96,7 @@ class ModerationRuleCreate(BaseModel):
 
 
 class ChangePasswordRequest(BaseModel):
+    current_password: str
     new_password: str
     confirm_password: str
 

--- a/backend/tests/test_citizen.py
+++ b/backend/tests/test_citizen.py
@@ -83,11 +83,11 @@ class TestCitizenChangePassword:
         email = unique_email()
         client.post("/api/citizen/register", json={"email": email, "password": VALID_PASSWORD})
         login = client.post("/api/citizen/login", json={"email": email, "password": VALID_PASSWORD})
-        token = login.json()["access_token"]
+        token = login.json()["token"]
 
         r = client.put(
             "/api/citizen/change-password",
-            json={"current_password": VALID_PASSWORD, "new_password": "NytPass99!"},
+            json={"current_password": VALID_PASSWORD, "new_password": "NytPass99!", "confirm_password": "NytPass99!"},
             headers={"Authorization": f"Bearer {token}"},
         )
         assert r.status_code == 200
@@ -95,7 +95,7 @@ class TestCitizenChangePassword:
     def test_change_password_wrong_current(self, client, citizen_token):
         r = client.put(
             "/api/citizen/change-password",
-            json={"current_password": "ForkertGammelt1!", "new_password": "NytPass99!"},
+            json={"current_password": "ForkertGammelt1!", "new_password": "NytPass99!", "confirm_password": "NytPass99!"},
             headers={"Authorization": f"Bearer {citizen_token}"},
         )
         assert r.status_code == 401
@@ -103,7 +103,7 @@ class TestCitizenChangePassword:
     def test_change_password_weak_new(self, client, citizen_token):
         r = client.put(
             "/api/citizen/change-password",
-            json={"current_password": VALID_PASSWORD, "new_password": WEAK_PASSWORD},
+            json={"current_password": VALID_PASSWORD, "new_password": WEAK_PASSWORD, "confirm_password": WEAK_PASSWORD},
             headers={"Authorization": f"Bearer {citizen_token}"},
         )
         assert r.status_code == 400


### PR DESCRIPTION
## Sammenfatning

En logget-ind borger kunne skifte adgangskode **uden at kende det nuværende kodeord**. Hvis en angriber fik fat i en aktiv session (fx. via et stjålet JWT-token), kunne de permanent låse ejeren ude ved at skifte kodeord.

## Ændringer

**`backend/schemas.py`**
```python
# Før:
class ChangePasswordRequest(BaseModel):
    new_password: str
    confirm_password: str

# Efter:
class ChangePasswordRequest(BaseModel):
    current_password: str   # ← nyt påkrævet felt
    new_password: str
    confirm_password: str
```

**`backend/routers/citizen.py`**
```python
# Tilføjet som første check i citizen_change_password():
if not verify_password(data.current_password, citizen.password_hash):
    raise HTTPException(401, "Nuværende adgangskode er forkert")
```

**`backend/tests/test_citizen.py`**
- `confirm_password` tilføjet til alle change-password test-payloads
- `access_token` → `token` (foregriper Sprint 1 fix #13)

## Note om admin-reset flow

Admin kan stadig nulstille en borgers kodeord via `PUT /api/admin/citizens/{id}/reset-password` — dette flow sætter `must_change_password = True` og kræver ikke det gamle kodeord, da admin handler på vegne af borgeren. Dette er uændret og korrekt.

## Test plan

- [ ] `pytest tests/test_citizen.py::TestCitizenChangePassword -v` — alle tre tests grønne
- [ ] Skift kodeord med korrekt nuværende kode → `200 OK`
- [ ] Skift kodeord med forkert nuværende kode → `401`
- [ ] Skift kodeord til svagt kodeord → `400`

## Relaterede issues

Closes #14

https://claude.ai/code/session_01QST3fNfc98pBpsiGXkBM4V