### PR TITLE
fix(security): reducer JWT-levetid til 60 min og tilføj refresh endpoint (#17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ env/
 # Environment variables (ALDRIG commit credentials)
 .env
 .env.local
+.env.development
 .env.production
 
 # Database (lokal testdata)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,7 +16,10 @@ DATABASE_URL=sqlite:///./norddjurs.db
 #   python -c "import secrets; print(secrets.token_hex(32))"
 SECRET_KEY=SKIFT-MIG-generér-med-kommandoen-ovenfor
 ALGORITHM=HS256
-ACCESS_TOKEN_EXPIRE_MINUTES=10080
+# Access-token: kort levetid (anbefalet: 60 minutter)
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+# Refresh-token: bruges til stille fornyelse af access-token (anbefalet: 7 dage)
+REFRESH_TOKEN_EXPIRE_DAYS=7
 
 # ─── CORS ───
 # Kommaseparerede URLs til din frontend. Brug aldrig * i produktion.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -17,7 +17,8 @@ load_dotenv()
 
 SECRET_KEY = os.getenv("SECRET_KEY", "")
 ALGORITHM = os.getenv("ALGORITHM", "HS256")
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "10080"))  # 7 dage
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))    # 1 time
+REFRESH_TOKEN_EXPIRE_DAYS = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7"))         # 7 dage
 
 # Kendte usikre standardværdier der aldrig må bruges i produktion
 _UNSAFE_KEYS = {
@@ -59,6 +60,14 @@ def create_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
     to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_refresh_token(data: dict) -> str:
+    """Opret et refresh-token med længere levetid (REFRESH_TOKEN_EXPIRE_DAYS)."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire, "type": "refresh"})
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
 

--- a/backend/routers/citizen.py
+++ b/backend/routers/citizen.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from models import Citizen, Response, ResponseMetadata, Question, Theme, ConsentLog
-from auth import hash_password, verify_password, create_token, get_current_citizen
+from auth import hash_password, verify_password, create_token, create_refresh_token, get_current_citizen
 from schemas import (
     CitizenRegister, CitizenLogin, ConsentUpdate,
     MetadataUpdate, ChangePasswordRequest,
@@ -44,7 +44,8 @@ def citizen_register(request: Request, data: CitizenRegister, db: Session = Depe
     db.refresh(citizen)
 
     token = create_token({"sub": citizen.id, "role": "citizen"})
-    return {"token": token, "citizen": citizen_dict(citizen)}
+    refresh_token = create_refresh_token({"sub": citizen.id, "role": "citizen"})
+    return {"token": token, "refresh_token": refresh_token, "citizen": citizen_dict(citizen)}
 
 
 @router.post("/login")
@@ -59,7 +60,16 @@ def citizen_login(request: Request, data: CitizenLogin, db: Session = Depends(ge
             raise HTTPException(401, "Den midlertidige adgangskode er udløbet. Kontakt en administrator for at få en ny.")
 
     token = create_token({"sub": citizen.id, "role": "citizen"})
-    return {"token": token, "citizen": citizen_dict(citizen)}
+    refresh_token = create_refresh_token({"sub": citizen.id, "role": "citizen"})
+    return {"token": token, "refresh_token": refresh_token, "citizen": citizen_dict(citizen)}
+
+
+@router.post("/refresh")
+@limiter.limit("30/minute")
+def citizen_refresh_token(request: Request, citizen: Citizen = Depends(get_current_citizen)):
+    """Udsted et nyt access-token baseret på et gyldigt token (bruges til stille fornyelse)."""
+    token = create_token({"sub": citizen.id, "role": "citizen"})
+    return {"token": token}
 
 
 @router.get("/me")


### PR DESCRIPTION
## Sammenfatning

JWT access-tokens levede i 7 dage (10.080 minutter) uden mulighed for fornyelse. Et kompromitteret token — fx. stjålet fra `localStorage` via XSS — var gyldigt i op til en uge uden mulighed for invalidering.

## Ændringer

**`backend/auth.py`**
- `ACCESS_TOKEN_EXPIRE_MINUTES`: `10080` (7 dage) → `60` (1 time)
- `REFRESH_TOKEN_EXPIRE_DAYS`: ny variabel, default `7` dage
- `create_refresh_token()` tilføjet — udsteder token med `"type": "refresh"` claim og lang levetid

**`backend/routers/citizen.py`**
- `POST /register` og `POST /login` returnerer nu begge tokens:
```json
{
  "token": "<access-token, 60 min>",
  "refresh_token": "<refresh-token, 7 dage>",
  "citizen": { ... }
}
```
- Nyt endpoint `POST /api/citizen/refresh` (rate limit: 30/min):
  - Kræver gyldigt token (access eller refresh)
  - Returnerer nyt access-token
  - Bruges til stille fornyelse i frontend 5 min før udløb

**`backend/.env.example`**
- `ACCESS_TOKEN_EXPIRE_MINUTES=60` (opdateret fra 10080)
- `REFRESH_TOKEN_EXPIRE_DAYS=7` (ny)

## Frontend-opgave (separat)

Frontend skal implementere automatisk token-refresh — dette hænger naturligt sammen med #24 (App.jsx-opdeling). Pseudokode:

```js
// Kald /api/citizen/refresh når token er < 5 min fra udløb
const payload = JSON.parse(atob(token.split('.')[1]));
const expiresIn = payload.exp * 1000 - Date.now();
if (expiresIn < 5 * 60 * 1000) {
  const { token: newToken } = await apiFetch('/api/citizen/refresh', {}, token).then(r => r.json());
  localStorage.setItem('citizenToken', newToken);
}
```

## Test plan

- [ ] Login returnerer både `token` og `refresh_token`
- [ ] `POST /api/citizen/refresh` med gyldigt token → nyt access-token
- [ ] `POST /api/citizen/refresh` uden token → `401`
- [ ] Verificer at nyt access-token udløber om ~60 min (tjek `exp` claim)
- [ ] `.env.example` afspejler nye standardværdier

## Relaterede issues

Closes #17

https://claude.ai/code/session_01QST3fNfc98pBpsiGXkBM4V