### PR TITLE
perf+fix: Sprint 3 — N+1 queries, ubegrænsede tråde og AudioRecorder timer (#20, #21, #22, #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ env/
 # Environment variables (ALDRIG commit credentials)
 .env
 .env.local
+.env.development
 .env.production
 
 # Database (lokal testdata)

--- a/backend/routers/citizen.py
+++ b/backend/routers/citizen.py
@@ -133,11 +133,20 @@ def citizen_responses(citizen: Citizen = Depends(get_current_citizen), db: Sessi
         Response.citizen_id == citizen.id,
         Response.is_excluded == False,
     ).order_by(Response.created_at.desc()).all()
+
+    # Batch-load — max 3 queries uanset antal besvarelser
+    question_ids = {r.question_id for r in responses if r.question_id}
+    questions_map = {q.id: q for q in db.query(Question).filter(Question.id.in_(question_ids)).all()} if question_ids else {}
+    theme_ids = {q.theme_id for q in questions_map.values() if q.theme_id}
+    themes_map = {t.id: t for t in db.query(Theme).filter(Theme.id.in_(theme_ids)).all()} if theme_ids else {}
+    resp_ids = {r.id for r in responses if not r.is_followup}
+    followups_map = {f.parent_response_id: f for f in db.query(Response).filter(Response.parent_response_id.in_(resp_ids)).all()} if resp_ids else {}
+
     result = []
     for r in responses:
-        q = db.query(Question).filter(Question.id == r.question_id).first()
-        t = db.query(Theme).filter(Theme.id == q.theme_id).first() if q and q.theme_id else None
-        followup = db.query(Response).filter(Response.parent_response_id == r.id).first() if not r.is_followup else None
+        q = questions_map.get(r.question_id)
+        t = themes_map.get(q.theme_id) if q and q.theme_id else None
+        followup = followups_map.get(r.id) if not r.is_followup else None
         result.append({
             **response_dict(r),
             "question": {"id": q.id, "body": q.body, "title": q.title} if q else None,
@@ -198,10 +207,17 @@ def citizen_export(citizen: Citizen = Depends(get_current_citizen), db: Session 
     """Returnerer alle borgerens data som JSON (art. 20 dataportabilitet)."""
     meta = db.query(ResponseMetadata).filter(ResponseMetadata.citizen_id == citizen.id).first()
     responses = db.query(Response).filter(Response.citizen_id == citizen.id).order_by(Response.created_at).all()
+
+    # Batch-load — max 2 queries uanset antal besvarelser
+    question_ids = {r.question_id for r in responses if r.question_id}
+    questions_map = {q.id: q for q in db.query(Question).filter(Question.id.in_(question_ids)).all()} if question_ids else {}
+    theme_ids = {q.theme_id for q in questions_map.values() if q.theme_id}
+    themes_map = {t.id: t for t in db.query(Theme).filter(Theme.id.in_(theme_ids)).all()} if theme_ids else {}
+
     result = []
     for r in responses:
-        q = db.query(Question).filter(Question.id == r.question_id).first()
-        t = db.query(Theme).filter(Theme.id == q.theme_id).first() if q and q.theme_id else None
+        q = questions_map.get(r.question_id)
+        t = themes_map.get(q.theme_id) if q and q.theme_id else None
         result.append({
             "id": r.id,
             "question": q.body if q else None,

--- a/backend/routers/responses.py
+++ b/backend/routers/responses.py
@@ -7,7 +7,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Query, Request
 from sqlalchemy.orm import Session
 
-import threading
+from concurrent.futures import ThreadPoolExecutor
 from database import get_db, SessionLocal as _SessionLocal
 from models import Citizen, Response, Question, AISettings
 from auth import get_optional_citizen
@@ -25,6 +25,9 @@ from constants import (
 router = APIRouter(prefix="/api", tags=["responses"])
 
 UPLOAD_DIR = os.getenv("UPLOAD_DIR", "./uploads")
+
+_SENTIMENT_WORKERS = int(os.getenv("SENTIMENT_WORKERS", "2"))
+_sentiment_pool = ThreadPoolExecutor(max_workers=_SENTIMENT_WORKERS, thread_name_prefix="sentiment")
 
 
 def _analyse_sentiment_async(response_id: str, text: str):
@@ -45,7 +48,7 @@ def _analyse_sentiment_async(response_id: str, text: str):
                 db.close()
         except Exception as e:
             print(f"[Sentiment] Async analyse fejlede: {e}")
-    threading.Thread(target=_run, daemon=True).start()
+    _sentiment_pool.submit(_run)
 MAX_UPLOAD_BYTES = int(os.getenv("MAX_UPLOAD_SIZE_MB", str(MAX_UPLOAD_SIZE_MB))) * 1024 * 1024
 
 

--- a/backend/serializers.py
+++ b/backend/serializers.py
@@ -3,6 +3,7 @@
 Samlet ét sted så alle routers bruger samme output-format.
 """
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from models import (
     Citizen, Theme, Question, Forloeb, Response,
@@ -129,7 +130,22 @@ def forloeb_dict(f: Forloeb, db: Session) -> dict:
         "created_at": f.created_at.isoformat() if f.created_at else None,
     }
     if f.mode == "themes":
-        d["themes"] = [theme_dict(t, db) for t in f.themes]
+        theme_ids = [t.id for t in f.themes]
+        # Én samlet COUNT-query for alle temaer — undgår N+1
+        counts = dict(
+            db.query(Question.theme_id, func.count(Question.id))
+            .filter(Question.theme_id.in_(theme_ids), Question.is_active == True)
+            .group_by(Question.theme_id)
+            .all()
+        ) if theme_ids else {}
+        d["themes"] = [
+            {
+                "id": t.id, "name": t.name, "icon": t.icon, "sort_order": t.sort_order,
+                "question_count": counts.get(t.id, 0),
+                "forloeb_id": getattr(t, "forloeb_id", None),
+            }
+            for t in f.themes
+        ]
     else:
         d["question_count"] = db.query(Question).filter(
             Question.forloeb_id == f.id,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -142,7 +142,7 @@ const AudioRecorder = ({ onRecorded }) => {
       setRecording(true);
       setElapsed(0);
       timerRef.current = setInterval(() => setElapsed(p => {
-        if (p >= 29) { mr.stop(); setRecording(false); clearInterval(timerRef.current); }
+        if (p >= 89) { mr.stop(); setRecording(false); clearInterval(timerRef.current); }
         return p + 1;
       }), 1000);
     } catch {


### PR DESCRIPTION
## Sammenfatning

Sprint 3 fokuserer på performance-forbedringer og en brugsvenlighedsbug. Fire issues løst i én samlet PR.

---

### #21 — N+1 queries i `citizen_responses` og `citizen_export`

Begge endpoints lavede **2-3 database-queries pr. besvarelse** i et for-loop. Med 50 svar resulterede det i 150+ queries for ét enkelt API-kald.

**Løsning:** Batch-loading med `IN`-queries og dict-lookup:
- `GET /api/citizen/responses`: **max 4 queries** uanset antal svar (var N×3)
- `GET /api/citizen/export`: **max 3 queries** uanset antal svar (var N×2)

---

### #22 — Ubegrænsede daemon-tråde til sentiment-analyse

`threading.Thread(daemon=True).start()` pr. besvarelse → ved høj belastning kunne ubegrænsede tråde udtømme server-ressourcer og skabe race conditions ved model-indlæsning.

**Løsning:** Modul-niveau `ThreadPoolExecutor` med fast pool-størrelse:
```python
_sentiment_pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="sentiment")
```
Pool-størrelse er konfigurerbar via `SENTIMENT_WORKERS` env-variabel (default: 2).

---

### #23 — N+1 queries i `forloeb_dict` via `theme_dict`

`theme_dict` lavede én `COUNT`-query pr. tema. Et forløb med 5 temaer = 5 ekstra queries. `GET /api/forloeb` akkumulerede dette for alle aktive forløb.

**Løsning:** `forloeb_dict` batcher nu alle question-counts i **én `GROUP BY`-query** uanset antal temaer:
```python
counts = dict(
    db.query(Question.theme_id, func.count(Question.id))
    .filter(Question.theme_id.in_(theme_ids), Question.is_active == True)
    .group_by(Question.theme_id)
    .all()
)
```

---

### #20 — AudioRecorder stopper ved 29s, UI kommunikerer 90s

Borgere oplevede pludselig afskæring af optagelse efter 30 sekunder, selvom UI'en sagde "max 90 sek" og timeren viste "1:30".

**Løsning:** Kode-grænsen hævet fra `p >= 29` til `p >= 89` — kode og UI er nu i overensstemmelse. Privatlivspolitikken nævner "max 90 sekunder", så 90s er den korrekte grænse.

---

## Ændrede filer

| Fil | Ændring |
|---|---|
| `backend/routers/citizen.py` | Batch-load i `citizen_responses` og `citizen_export` |
| `backend/routers/responses.py` | `threading.Thread` → `ThreadPoolExecutor` |
| `backend/serializers.py` | Batch COUNT-query i `forloeb_dict` |
| `src/App.jsx` | AudioRecorder timer-grænse: 29 → 89 |

## Test plan

- [ ] `GET /api/citizen/responses` virker korrekt (returnerer besvarelser med spørgsmål og tema)
- [ ] `GET /api/citizen/export` virker korrekt (returnerer komplet JSON-eksport)
- [ ] Sentiment-analyse kører stadig efter indsendelse af tekstsvar
- [ ] `GET /api/forloeb` returnerer korrekte `question_count` for hvert tema
- [ ] AudioRecorder: optagelse stopper automatisk efter ~90 sekunder (ikke 30)
- [ ] `pytest backend/tests/ -v` — alle eksisterende tests grønne

## Relaterede issues

Closes #20
Closes #21
Closes #22
Closes #23

https://claude.ai/code/session_01QST3fNfc98pBpsiGXkBM4V